### PR TITLE
Set MRA rotation based on core output

### DIFF
--- a/releases/Freeze.mra
+++ b/releases/Freeze.mra
@@ -10,7 +10,7 @@
 	<rbf>freeze</rbf>
 	<about></about>
 	<resolution>15kHz</resolution>
-	<rotation>vertical(cw)</rotation>
+	<rotation>vertical(ccw)</rotation>
 	<flip></flip>
 	<players>2</players>
 	<joystick>2-way</joystick>

--- a/releases/Jack the Giantkiller (set 1).mra
+++ b/releases/Jack the Giantkiller (set 1).mra
@@ -10,7 +10,7 @@
 	<rbf>freeze</rbf>
 	<about></about>
 	<resolution>15kHz</resolution>
-	<rotation>vertical(cw)</rotation>
+	<rotation>vertical(ccw)</rotation>
 	<flip></flip>
 	<players>2</players>
 	<joystick>2-way</joystick>

--- a/releases/Super Casino.mra
+++ b/releases/Super Casino.mra
@@ -10,7 +10,7 @@
 	<rbf>freeze</rbf>
 	<about></about>
 	<resolution>15kHz</resolution>
-	<rotation>vertical(cw)</rotation>
+	<rotation>vertical(ccw)</rotation>
 	<flip></flip>
 	<players>2</players>
 	<joystick>2-way</joystick>

--- a/releases/Tri-Pool (Casino Tech).mra
+++ b/releases/Tri-Pool (Casino Tech).mra
@@ -10,7 +10,7 @@
 	<rbf>freeze</rbf>
 	<about></about>
 	<resolution>15kHz</resolution>
-	<rotation>vertical(cw)</rotation>
+	<rotation>vertical(ccw)</rotation>
 	<flip></flip>
 	<players>2</players>
 	<joystick>2-way</joystick>

--- a/releases/Zzyzzyxx (set 1).mra
+++ b/releases/Zzyzzyxx (set 1).mra
@@ -10,7 +10,7 @@
 	<rbf>freeze</rbf>
 	<about></about>
 	<resolution>15kHz</resolution>
-	<rotation>vertical(cw)</rotation>
+	<rotation>vertical(ccw)</rotation>
 	<flip></flip>
 	<players>2</players>
 	<joystick>2-way</joystick>


### PR DESCRIPTION
Similar situation to MrJong. Mame asserts that this is a CW game, but the core outputs CCW. Because direct video uses the MRA for rotation direction, we should make them match.